### PR TITLE
HD-104389 Accounts > Confirm that oauth failure on accounts can be safely recovered/retried

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ yarn add freedom-accounts-util
 ```
 const accounts = require('freedom-accounts-util');
 
-accounts.configure({base_url: '', path: '', client_id: '', client_secret: '', client_expiry: 300, server_expiry: 300, disable_caching: false});
+accounts.configure({base_url: '', path: '', client_id: '', client_secret: '', client_expiry: 300, server_expiry: 300, disable_caching: false, retry_count: ''});
 // or
 accounts.configure(config.ACCOUNTS);
 ```
 Notes:
 * Client and server expiry are in seconds. 
 * `disable_caching` disables caching when true (useful for tests).
+* `retry_count` refers to the maximum number of retries for cuddle requests to accounts. Default value is 3 but it can be configured by service that uses it.
 
 ## Usage:
 For Express Servers:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,16 @@ yarn add freedom-accounts-util
 ```
 const accounts = require('freedom-accounts-util');
 
-accounts.configure({base_url: '', path: '', client_id: '', client_secret: '', client_expiry: 300, server_expiry: 300, disable_caching: false, retry_count: ''});
+accounts.configure({
+    base_url: '',
+    path: '',
+    client_id: '',
+    client_secret: '',
+    client_expiry: 300,
+    server_expiry: 300,
+    disable_caching: false,
+    retry_count: 3}
+);
 // or
 accounts.configure(config.ACCOUNTS);
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freedom-accounts-util",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Utility helper for OAuth2.0 calls to Freedom! Accounts",
   "main": "index.js",
   "author": "MCN Freedom! Tech. Inc. <development@freedom.tm>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freedom-accounts-util",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Utility helper for OAuth2.0 calls to Freedom! Accounts",
   "main": "index.js",
   "author": "MCN Freedom! Tech. Inc. <development@freedom.tm>",

--- a/src/client.js
+++ b/src/client.js
@@ -29,6 +29,7 @@ function generate_token (scopes) {
     return cudl.post
         .to(config.base_url + config.path + '/oauth/token')
         .send(payload)
+        .max_retry(config.retry_count)
         .promise()
         .then(result => {
             cache.set('client', scopes_string, result, config.client_expiry);
@@ -49,6 +50,7 @@ function refresh_token (refresh_token) {
     return cudl.post
         .to(config.base_url + config.path + '/oauth/token')
         .send(payload)
+        .max_retry(config.retry_count)
         .promise()
         .then(result => {
             if (scopes_string) {

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@ const config = {
     client_expiry: 300, // in seconds
     server_expiry: 300, // in seconds
     disable_caching: false,
+    retry_count: 3,
     configure: configure
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -58,6 +58,7 @@ function get_token_info (access_token) {
     return cudl.get
         .to(config.base_url + config.path + '/oauth/tokeninfo')
         .send({access_token: access_token})
+        .max_retry(config.retry_count)
         .promise()
         .then(result => {
             if (result.scopes) {


### PR DESCRIPTION
<!--
    Title your pull request with the following:
        <ticket-id> <ticket-name>

    If your pull request is not yet ready for reviewing*:
        [WIP] <ticket-id> <ticket-name>

    If your pull request should be ignored by the CI but is ready for reviewing*:
        [CI SKIP] <ticket-id> <ticket-name>

    *Note that the CI will ignore pull requests with either "[WIP]",
    "[CI SKIP]", or "[SKIP CI]" on the PR title (case insensitive).
-->

## Ticket references
- [HD-104389 Accounts > Confirm that oauth failure on accounts can be safely recovered/retried](https://freedom.myjetbrains.com/youtrack/issue/HD-104389)

## Summary of changes
<!--
    Describe the change and why it was introduced. Ideally, this will also be
    used as the commit message when we do squash merge.

    This is better presented in paragraph form. Only use bullet form when
    enumerating specific parts of the change.

    Include screenshots, if possible.
-->
Added retry on cuddle requests to accounts. Default max number of retries is 3, but it can be configured by other projects using `accounts.configure({..., retry_count: <value>, ...})`; 

Unit test has also been added for the retry functionality.

Package version was updated to 1.1.0

## Checklist
<!--
     Mark the things that have been followed.
-->
- [x] bugfix
- [ ] new feature
- [ ] breaking change
- [x] added unit tests
- [x] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated

## Testing
<!--
    Include this if we need manual testing and not a unit test.
    If the tests do not reach 10 lines, add it here, else move it to a document and link it to this section.
-->
* Execute `grunt test` in root directory. Verify that all tests are passing. No manual tests needed since additional unit tests already covered it.

