### PR TITLE
ZULU-90 Update freedom-accounts-util to specify required scopes in the error when access token does not have scopes

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -78,7 +78,7 @@ function get_token_info (access_token) {
 
 function check_token_validity ({result, access_token, required_scopes}) {
     return new Promise((resolve, reject) => {
-        if (!result.scopes) {
+        if (!_.has(result, 'scopes')) {
             cache.forget('server', access_token);
             return reject(new Error('Something went wrong, server did not return scopes, please try again.'));
         }

--- a/test/server.js
+++ b/test/server.js
@@ -135,6 +135,29 @@ describe('verify_scopes', function () {
         });
     });
 
+    it('should fail with tokens that have blank scopes', function () {
+        let accounts_nock = nocks.token_info('notjrrtoken')
+            .reply(200, {scopes: ''});
+
+        const request = httpMocks.createRequest({
+            method: 'GET',
+            url: '/test',
+            headers: {'Access-Token': 'notjrrtoken'}
+        });
+
+
+        return accounts.verify_scopes(scopes)(
+            request, null, error_handler
+        ).catch(error => {
+            error.should.have.property('message');
+            error.message.should.be.a('string');
+            error.message.should.equal(
+                'You need at least one of the ff. scopes to access this endpoint: ' + scopes.join(' ')
+            );
+            accounts_nock.isDone().should.equal(true);
+        });
+    });
+
     it('should succeed with proper provided access token', function () {
         let accounts_nock = nocks.token_info('jrrtoken')
             .reply(200, responses.valid_token_info);


### PR DESCRIPTION
<!--
    Title your pull request with the following:
        <ticket-id> <ticket-name>

    If your pull request is not yet ready for reviewing*:
        [WIP] <ticket-id> <ticket-name>

    If your pull request should be ignored by the CI but is ready for reviewing*:
        [CI SKIP] <ticket-id> <ticket-name>

    *Note that the CI will ignore pull requests with either "[WIP]",
    "[CI SKIP]", or "[SKIP CI]" on the PR title (case insensitive).
-->

## Ticket references
- [ZULU-90](https://freedom.myjetbrains.com/youtrack/issue/ZULU-90)

## Summary of changes
<!--
    Describe the change and why it was introduced. Ideally, this will also be
    used as the commit message when we do squash merge.

    This is better presented in paragraph form. Only use bullet form when
    enumerating specific parts of the change.

    Include screenshots, if possible.
-->
* Accept returned value from account even when scopes is blank and return needed scopes instead of returning error

## Checklist
<!--
     Mark the things that have been followed.
-->
- [x] bugfix
- [ ] new feature
- [ ] breaking change
- [ ] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated

## Testing
<!--
    Include this if we need manual testing and not a unit test.
    If the tests do not reach 10 lines, add it here, else move it to a document and link it to this section.
-->
Unit tests should pass.
