### PR TITLE
HD-105344 [Auto-Release] Tunes > Auto-release script stopped running

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "type": "git",
     "url": "https://github.com/anyTV/freedom-accounts-util.git"
   },
-  "keywords": ["accounts", "anytv", "freedom"],
+  "keywords": [
+    "accounts",
+    "anytv",
+    "freedom"
+  ],
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
@@ -26,7 +30,7 @@
     "node-mocks-http": "^1.6.6"
   },
   "dependencies": {
-    "cuddle": "^1.3.1",
+    "cuddle": "^1.3.3",
     "lodash": "^4.17.4",
     "moment": "^2.19.3"
   }


### PR DESCRIPTION
## Ticket references
- [HD-105344 [Auto-Release] Tunes > Auto-release script stopped running](https://freedom.myjetbrains.com/youtrack/issue/HD-105344)

## Summary of changes
Update cuddle version to apply fix for invalid grant type.

## Checklist
<!--
     Mark the things that have been followed.
-->
- [x] bugfix
- [ ] new feature
- [ ] breaking change
- [ ] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated

## Testing
No test needed
